### PR TITLE
Switched to radial cutoff, changed import and export formats

### DIFF
--- a/parse_data.cpp
+++ b/parse_data.cpp
@@ -3,46 +3,81 @@
 #include <string>
 #include <cassert>
 #include <iostream>
+#include <iomanip>
 #include <cmath>
 #include <cstdlib>
 
 //parser for polar coordinate data exported from RPI CSDT CSnap application
 
-//function to determine distance between two points
-float distanceBetween(const float radius_1, const float angle_1, const float radius_2, const float angle_2) {
-	//convert to cartesian to make distance calculation easier
-	const float x1 = radius_1*cos(angle_1 * 3.14159/180.0);		
-	const float x2 = radius_2*cos(angle_2 * 3.14159/180.0);	
-	const float y1 = radius_1*sin(angle_1 * 3.14159/180.0);
-	const float y2 = radius_2*sin(angle_2 * 3.14159/180.0);
-	float arg = pow((x2-x1), 2) + pow((y2-y1), 2);
-	float distance = pow(arg, .5);
-	return distance;
+void removeDuplicates(std::vector<float>& radii, std::vector<float>& angles) {
+	std::vector<float> unique_radii;
+	std::vector<float> unique_angles;
+
+	assert(radii.size() == angles.size());
+	for(unsigned int i = 0; i < radii.size(); i++) {
+
+		bool is_duplicate = false;
+
+		for(unsigned int j = 0; j < radii.size(); j++) {
+
+			if(radii[i] == radii[j] && angles[i] == angles[j] && i != j) {
+				is_duplicate = true;
+			}
+		}
+
+		if(not(is_duplicate)) {
+			unique_radii.push_back(radii[i]);
+			unique_angles.push_back(angles[i]);
+		}
+	}
+	radii = unique_radii;
+	angles = unique_angles;
 }
 
-/*
-	CSnap data has a lot of extraneous points, and that makes it difficult to print the patterns quickly.
-	This will take points close to one another, determined by some threshold, min_distance, and remove them.
-*/
+//rounds radius values and places all angles in the 0-360 degree range
+void roundPoints(std::vector<float>& radii, std::vector<float>& angles) {
+	for(unsigned int i = 0; i < radii.size(); i++) {
+		radii[i] = roundf(radii[i]*100) / 100;
+	}
 
-void simplifyPoints(std::vector<float>& radii, std::vector<float>& angles, const float min_distance) {
+	for(unsigned int j = 0; j < angles.size(); j++) {
+		angles[j] = remainder(angles[j], 360.0);
+		if(angles[j] < 0) {
+			angles[j] = 360.0 + angles[j];
+		}
+	}
+}
+
+//outputs radii and angles, separated by a line break
+//this format is easiest to copy into the Arduino IDE as an array
+void writeToOutput(std::ofstream& output, const std::vector<float>& radii, const std::vector<float>& angles) {
+	assert(radii.size() == angles.size());
+	
+	for(unsigned int i = 0; i < radii.size(); i++) {
+		output << std::setprecision(2) << std::fixed << fabs((radii[i]/10));
+		if(i != radii.size() - 1) {
+			output << ',';
+		}
+	}
+
+	output << std::endl;
+
+	for(unsigned int j = 0; j < angles.size(); j++) {
+		output << std::setprecision(2) << std::fixed << angles[j];
+		if(j != angles.size() - 1) {
+			output << ',';
+		}
+	}
+}
+
+
+//removes all points further out than some user-specified radius
+void cutToSize(std::vector<float>& radii, std::vector<float>& angles, const float max_radius) {
 	std::vector<float> valid_radii;
 	std::vector<float> valid_angles;
 
 	for(unsigned int i = 0; i < radii.size(); i++) {
-
-		bool point_is_valid = true;
-
-		for (unsigned int j = 0; j < radii.size(); j++) { //set a flag if radii[i] is too close to any other point in the pattern
-
-			float distance = distanceBetween(radii[i], angles[i], radii[j], angles[j]);
-			
-			if(distance < min_distance && i!= j) {
-				point_is_valid = false;
-			}
-		}
-
-		if (point_is_valid) {
+		if(not(radii[i] > max_radius) && radii[i] != 0) {
 			valid_radii.push_back(radii[i]);
 			valid_angles.push_back(angles[i]);
 		}
@@ -52,50 +87,7 @@ void simplifyPoints(std::vector<float>& radii, std::vector<float>& angles, const
 	angles = valid_angles;
 }
 
-void writeToOutput(std::ofstream& output, const std::vector<float>& radii, const std::vector<float>& angles) {
-	assert(radii.size() == angles.size());
-	
-	/*
-		iterate through the points, checking for duplicates
-	*/
-
-	std::vector<unsigned int> duplicates;
-	assert(radii.size() == angles.size());
-	for(unsigned int k = 0; k < radii.size(); k++) {
-		for(unsigned int l = 0; l < radii.size(); l++) {
-			if (radii[k] == radii[l] && angles[k] == angles[l] && k != l) {
-				duplicates.push_back(k);
-			}
-		}
-	}
-
-	for(unsigned int i = 0; i < radii.size(); i++) {
-		
-		/*
-			check if the point is a duplicate
-		*/
-
-		bool is_duplicate = false;
-
-		for(unsigned int j = 0; j < duplicates.size(); j++) {
-			if(i == duplicates[j]) {
-				is_duplicate = true;
-			}
-		}
-
-		if (not(is_duplicate)) {
-			output << radii[i] << ',' << angles[i];
-			if(i != radii.size() - 1) {
-				output << std::endl;
-			}
-		}
-	}
-}
-
-/*
-	function to read the data exported from CSnap into two vectors, radii and angles
-*/
-
+//reads csv into two vectors, radii and angles
 void readFile(std::ifstream& input, std::vector<float>& radii, std::vector<float>& angles) {
 	
 	bool is_radius = true; //boolean flag to switch between radius and angle vectors
@@ -103,11 +95,12 @@ void readFile(std::ifstream& input, std::vector<float>& radii, std::vector<float
 	
 	while(input.get(c)) {
 		std::string val = "";
-		if (c != '_' && c != ',') { //radius and angle are separated by '_'; coordinate pairs by ','
-			while(c != '_' && c != ',' && input.good()) { //read variable-length value from file
-				val += c;
-				input.get(c);
-			}
+		while(c != ',' && c != '\n' && input.good()) { //read variable-length value from file
+			val += c;
+			input.get(c);
+		}
+
+		if (val != "") {
 
 			float f_val = strtof(val.c_str(), NULL); //convert string to float
 
@@ -129,12 +122,15 @@ int main(int argc, char* argv[]) {
 	std::vector<float> angles;
 	std::string input_file_name = argv[1];
 	std::string output_file_name = argv[2];
-	float min_distance = strtof(argv[3], NULL);
+	float max_radius = strtof(argv[3], NULL);
 	
 	input_file.open(input_file_name.c_str());
 	output_file.open(output_file_name.c_str());
 	
 	readFile(input_file, radii, angles);
-	simplifyPoints(radii, angles, min_distance);
+	roundPoints(radii, angles);
+	removeDuplicates(radii, angles);
+	cutToSize(radii, angles, max_radius);
 	writeToOutput(output_file, radii, angles);
+	std::cout << radii.size() << " points in the pattern." << std::endl;
 };


### PR DESCRIPTION
Removing points based on distance from other points degraded the pattern too much, with no real benefit.
I realized that the CSnap application only displays points out to a certain distance, so removing points based on radial distance makes the most sense, produces a pattern most similar to CSnap, and removes more points, all with none of the resolution trade-off of the previous method.

I also changed how the parser reads and writes data, since I wrote the necessary JS to export data directly from CSnap as a .csv. The output is formatted to write comma-separated radii to one line, and comma-separated angles to the other (without any negatives or angle values greater than 360). This allows me to copy the pattern directly into two vectors in the Arduino IDE, which is the easiest way (I think) to load and print a pattern.